### PR TITLE
fix: Add required account args

### DIFF
--- a/src/AccountList.js
+++ b/src/AccountList.js
@@ -32,7 +32,7 @@ export default createFragmentContainer(
   AccountList,
   graphql`
     fragment AccountList on PublicAPIClient {
-      accounts(first: $accountCount) {
+      accounts(first: $accountCount, orderBy: {field: BUSINESS_NAME, direction: ASC }) {
         edges {
           node {
             id


### PR DESCRIPTION
Application wouldn't start without the orderedBy arguments to account list.

<img width="426" alt="image" src="https://github.com/soundtrackyourbrand/soundtrack_api-example_app/assets/2387314/06999c42-3504-4b86-968e-2ed911b32076">
